### PR TITLE
Partials loose context variables

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,6 +45,12 @@ module.exports = function(grunt) {
           dev: 'this is global'
         }
       },
+      partials: {
+        options: {
+            src: 'test/fixtures/partial',
+            dist: 'tmp'
+        }
+      }
     },
 
     // Unit tests.

--- a/test/expected/partial.html
+++ b/test/expected/partial.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>partial page</title>
+</head>
+<body>
+  <div class="content">
+    <ul>
+        <li>
+          <a href="index.html">main</a>
+        </li>
+        <li>
+          <a href="inner.html">inner</a>
+        </li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/test/fixtures/partial/layout.mustache
+++ b/test/fixtures/partial/layout.mustache
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{title}}</title>
+</head>
+<body>
+  <h2>{{dev}}</h2>
+  <div class="content">
+    {{>content}}
+  </div>
+</body>
+</html>

--- a/test/fixtures/partial/pages/partial.json
+++ b/test/fixtures/partial/pages/partial.json
@@ -1,0 +1,7 @@
+{
+  "title": "partial page",
+  "items" : [
+    {"name": "main", "link": "index.html"},
+    {"name": "inner", "link": "inner.html"}
+  ]
+}

--- a/test/fixtures/partial/pages/partial.mustache
+++ b/test/fixtures/partial/pages/partial.mustache
@@ -1,0 +1,5 @@
+<ul>
+  {{#items}}
+    {{>partial}}
+  {{/items}}
+</ul>

--- a/test/fixtures/partial/partials/partial.mustache
+++ b/test/fixtures/partial/partials/partial.mustache
@@ -1,0 +1,3 @@
+<li>
+  <a href="{{link}}">{{name}}</a>
+</li>

--- a/test/mustache_html_test.js
+++ b/test/mustache_html_test.js
@@ -43,6 +43,15 @@ exports.mustache_html = {
     var expected = grunt.file.read('test/expected/custom.html');
     test.equal(actual, expected, 'page created.');
 
-    test.done();;
+    test.done();
+  },
+  partials: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/partial.html');
+    var expected = grunt.file.read('test/expected/partial.html');
+    test.equal(actual, expected, 'page created.');
+
+    test.done();
   }
 };


### PR DESCRIPTION
All, or at least almost all mustache implementations supports context variables inheritance:

```html
{{#names}}
  {{> user}}
{{/names}}

user.mustache:
<strong>{{name}}</strong>
```

but it doesn't work here. Any ideas why?